### PR TITLE
Add some configuration options and fix region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ module "aws_static_site" {
   - `max_ttl` - the maximum amount of time, in seconds, that objects stay in CloudFront cache. Defaults to 1 year. Further details of all the TTL settings can be found in the AWS CloudFront [documentation.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
 - `countries` is a list of countries in [ISO 3166-alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) format that the CloudFront `restriction_type` applies to.
 - `allowed_origins` is a list of origins to allow getting items from the S3 bucket.
+- `index` is the index page for the website. Defaults to `index.html`.
+- `error_page` is the error page for the website. Defaults to `404.html`.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ module "aws_static_site" {
     tags = {
       Application = "Example"
     }
+
+    providers = {
+      aws.us-east-1 = aws
+    }
 }
 ```
 
@@ -78,3 +82,6 @@ Finally, an IAM user is created, an access key is given to this user, and a poli
 ## Notes
 
 The certificate is created automatically by adding DNS entries to the Route 53 hosted zone. The script will wait up to two hours for the certificate to be issued. If your domain is not owned by Route 53, you may need to go to the Route 53 hosted zone, look at the NS record, and assign your domain those nameservers. If the script times out because this was not done rerunning `terraform apply` after making sure the nameservers are correct should allow the module to continue.
+
+A provider `aws.us-east-1` has to be passed to the module - this is because CloudFront certificates must be requested 
+in us-east-1.

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+  alias = "us-east-1"
+}
+
 data "aws_route53_zone" "zone" {
     name  = "${local.zone_domain_name}."
 }
@@ -124,6 +129,7 @@ resource "aws_acm_certificate" "cert" {
     subject_alternative_names = [local.redirect_domain]
     validation_method         = "DNS"
     tags                      = var.tags
+    provider                  = aws.us-east-1
 }
 
 resource "aws_route53_record" "cert" {

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_s3_bucket" "main" {
     policy = data.aws_iam_policy_document.bucket_policy.json
 
     website {
-      index_document = "index.html"
+      index_document = var.index
       error_document = "404.html"
     }
     force_destroy = true 

--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,7 @@ resource "aws_route53_record" "cert" {
 resource "aws_acm_certificate_validation" "cert" {
     certificate_arn         = aws_acm_certificate.cert.arn
     validation_record_fqdns = tolist(aws_route53_record.cert.*.fqdn)
+    provider                = aws.us-east-1
 
     timeouts {
       create = "2h"

--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     custom_error_response {
       error_code = 403
       response_code = 200
-      response_page_path = "/index.html"
+      response_page_path = "/${var.index}"
     }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket" "main" {
 
     website {
       index_document = var.index
-      error_document = "404.html"
+      error_document = var.error_document
     }
     force_destroy = true 
 
@@ -212,7 +212,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     custom_error_response {
       error_code = 404
       response_code = 200
-      response_page_path = "/404.html"
+      response_page_path = "/${var.error_document}"
     }
 
     custom_error_response {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
+// CloudFront certificates have to be requested in us-east-1
 provider "aws" {
-  region = "us-east-1"
   alias = "us-east-1"
 }
 

--- a/test/integration/main.tf
+++ b/test/integration/main.tf
@@ -7,4 +7,8 @@ module "s3-static-site" {
     
     secret          = "ghhyryr678rhbjoh"
     domain = "example.davidvargas.me"
+
+    providers = {
+        aws.us-east-1 = aws
+    }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "index" {
     description = "Index page for the website"
     default     = "index.html"
 }
+
+variable "error_document" {
+    type        = string
+    description = "Error page for the website"
+    default     = "404.html"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,9 @@ variable "allowed_origins" {
     description = "Other origins allowed to access items from the bucket."
     default     = []
 }
+
+variable "index" {
+    type        = string
+    description = "Index page for the website"
+    default     = "index.html"
+}


### PR DESCRIPTION
[CloudFront requires certificates to be in `us-east-1` for some reason](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-aws-region), so I've added a provider alias.

I also made the index and 404 page configurable.

Thanks for creating this module! It was a big help for me - I'm using it to host [my personal site](https://ael.red/) now 😁 